### PR TITLE
Fixed the image path of the default loading image.

### DIFF
--- a/css/mediaboxAdvBlack.css
+++ b/css/mediaboxAdvBlack.css
@@ -48,7 +48,7 @@
 }
 
 #mbCenter.mbLoading {
-	background: #000 url(/images/loading.gif) no-repeat center;
+	background: #000 url(/images/blackLoading.gif) no-repeat center;
 		/*	This style is applied only during animation.	*/
 		/*	For example, the next lines turn off shadows	*/
 		/*	improving browser performance on slow systems.	*/


### PR DESCRIPTION
Hey,

I just downloaded the source for the **1.4.6 tag**, and the loading.gif image doesn't exist.

Since the theme used is in a black color, i've switched the loading image to be blackLoading.gif instead.
