### PR TITLE
Fixed typo in ClickBlock preventing the code from executing due to wrong 

### DIFF
--- a/Source/mediaboxAdv.js
+++ b/Source/mediaboxAdv.js
@@ -245,7 +245,7 @@ var Mediabox;
 			var links = this;
 
 			links.addEvent('contextmenu', function(e){
-				if (options.clickBlock && this.toString().match(/\.gif|\.jpg|\.jpeg|\.png/i)) e.stop();
+				if (_options.clickBlock && this.toString().match(/\.gif|\.jpg|\.jpeg|\.png/i)) e.stop();
 			});
 
 			links.removeEvents("click").addEvent("click", function() {


### PR DESCRIPTION
Fixed typo in ClickBlock preventing the code from executing due to wrong variable name. from 'options' to '_options' on line 248.
